### PR TITLE
FRI-54 Change CommitInformation to have source & target branch paths

### DIFF
--- a/src/main/java/org/snomed/aag/data/pojo/CommitInformation.java
+++ b/src/main/java/org/snomed/aag/data/pojo/CommitInformation.java
@@ -8,11 +8,11 @@ public class CommitInformation {
 	public static final String CLASSIFIED = "classified";
 
 	public enum CommitType {
-		CONTENT, REBASE, PROMOTION;
-
+		CONTENT, REBASE, PROMOTION
 	}
 
-	private String path;
+	private String sourceBranchPath;
+	private String targetBranchPath;
 	private CommitType commitType;
 	private long headTime;
 	private Map<String, Object> metadata;
@@ -20,8 +20,16 @@ public class CommitInformation {
 	public CommitInformation() {
 	}
 
-	public CommitInformation(String path, CommitType commitType, long headTime, Map<String, Object> metadata) {
-		this.path = path;
+	public CommitInformation(String sourceBranchPath, CommitType commitType, long headTime, Map<String, Object> metadata) {
+		this.sourceBranchPath = sourceBranchPath;
+		this.commitType = commitType;
+		this.headTime = headTime;
+		this.metadata = metadata;
+	}
+
+	public CommitInformation(String sourceBranchPath, String targetBranchPath, CommitType commitType, long headTime, Map<String, Object> metadata) {
+		this.sourceBranchPath = sourceBranchPath;
+		this.targetBranchPath = targetBranchPath;
 		this.commitType = commitType;
 		this.headTime = headTime;
 		this.metadata = metadata;
@@ -36,8 +44,12 @@ public class CommitInformation {
 		return false;
 	}
 
-	public String getPath() {
-		return path;
+	public String getSourceBranchPath() {
+		return sourceBranchPath;
+	}
+
+	public String getTargetBranchPath() {
+		return targetBranchPath;
 	}
 
 	public CommitType getCommitType() {
@@ -55,7 +67,8 @@ public class CommitInformation {
 	@Override
 	public String toString() {
 		return "CommitInformation{" +
-				"path='" + path + '\'' +
+				"sourceBranchPath='" + sourceBranchPath + '\'' +
+				", targetBranchPath='" + targetBranchPath + '\'' +
 				", commitType=" + commitType +
 				", headTime=" + headTime +
 				", metadata=" + metadata +

--- a/src/main/java/org/snomed/aag/data/services/AcceptanceService.java
+++ b/src/main/java/org/snomed/aag/data/services/AcceptanceService.java
@@ -104,19 +104,19 @@ public class AcceptanceService {
 	 * @param commitInformation Commit information including branch path and metadata.
 	 */
 	public void processCommit(CommitInformation commitInformation) {
-		final String branchPath = commitInformation.getPath();
-		final ProjectAcceptanceCriteria criteria = criteriaService.findEffectiveCriteriaWithMandatoryItems(branchPath);
+		final String sourceBranchPath = commitInformation.getSourceBranchPath();
+		final ProjectAcceptanceCriteria criteria = criteriaService.findEffectiveCriteriaWithMandatoryItems(sourceBranchPath);
 		if (criteria == null) {
 			LOGGER.info("ProjectAcceptanceCriteria not found for branch; nothing to process.");
 			return;
 		}
 
 		boolean classified = commitInformation.isClassified();
-		boolean projectLevel = criteria.isBranchProjectLevel(branchPath);
-		boolean taskLevel = criteria.isBranchTaskLevel(branchPath);
+		boolean projectLevel = criteria.isBranchProjectLevel(sourceBranchPath);
+		boolean taskLevel = criteria.isBranchTaskLevel(sourceBranchPath);
 
-		final Set<CriteriaItem> items = criteriaService.findItemsAndMarkSignOff(criteria, branchPath);
-		final Set<String> branchRoles = securityService.getBranchRoles(branchPath);
+		final Set<CriteriaItem> items = criteriaService.findItemsAndMarkSignOff(criteria, sourceBranchPath);
+		final Set<String> branchRoles = securityService.getBranchRoles(sourceBranchPath);
 
 		// Includes role check
 		Set<String> itemsShouldBeAccepted = items.stream()
@@ -140,13 +140,13 @@ public class AcceptanceService {
 
 
 		if (!itemsToUnaccept.isEmpty()) {
-			LOGGER.info("Rejecting items {} for branch {}, iteration {}", itemsToUnaccept, branchPath, criteria.getProjectIteration());
-			criteriaItemSignOffService.deleteItems(itemsToUnaccept, branchPath, criteria.getProjectIteration());
+			LOGGER.info("Rejecting items {} for branch {}, iteration {}", itemsToUnaccept, sourceBranchPath, criteria.getProjectIteration());
+			criteriaItemSignOffService.deleteItems(itemsToUnaccept, sourceBranchPath, criteria.getProjectIteration());
 		} else {
 			LOGGER.info("No Criteria Items to reject.");
 		}
 
-		persistItemsShouldBeAccepted(itemsShouldBeAccepted, acceptedItems, branchPath, commitInformation.getHeadTime(), criteria.getProjectIteration());
+		persistItemsShouldBeAccepted(itemsShouldBeAccepted, acceptedItems, sourceBranchPath, commitInformation.getHeadTime(), criteria.getProjectIteration());
 	}
 
 	@Async

--- a/src/main/java/org/snomed/aag/data/services/ProjectAcceptanceCriteriaService.java
+++ b/src/main/java/org/snomed/aag/data/services/ProjectAcceptanceCriteriaService.java
@@ -281,7 +281,7 @@ public class ProjectAcceptanceCriteriaService {
     public boolean incrementIfComplete(CommitInformation commitInformation) {
         verifyParams(commitInformation);
 
-        String path = commitInformation.getPath();
+        String path = commitInformation.getSourceBranchPath();
         ProjectAcceptanceCriteria projectAcceptanceCriteria = findEffectiveCriteriaWithMandatoryItems(path);
         if (projectAcceptanceCriteria == null) {
             throw new ServiceRuntimeException("No Project Acceptance Criteria found for branch.", HttpStatus.NOT_FOUND);

--- a/src/main/java/org/snomed/aag/data/validators/CommitInformationValidator.java
+++ b/src/main/java/org/snomed/aag/data/validators/CommitInformationValidator.java
@@ -21,9 +21,9 @@ public class CommitInformationValidator {
 			throw new IllegalArgumentException("No CommitType specified.");
 		}
 
-		String path = commitInformation.getPath();
-		if (path == null) {
-			throw new IllegalArgumentException("No path specified.");
+		String sourceBranchPath = commitInformation.getSourceBranchPath();
+		if (sourceBranchPath == null) {
+			throw new IllegalArgumentException("No sourceBranchPath specified.");
 		}
 
 		long headTime = commitInformation.getHeadTime();

--- a/src/main/java/org/snomed/aag/rest/ServiceIntegrationController.java
+++ b/src/main/java/org/snomed/aag/rest/ServiceIntegrationController.java
@@ -65,10 +65,10 @@ public class ServiceIntegrationController {
 		} else {
 			boolean pacComplete = projectAcceptanceCriteriaService.incrementIfComplete(commitInformation);
 			if (pacComplete) {
-				logger.info("Project Acceptance Criteria for {} is complete. Promotion is recommended.", commitInformation.getPath());
+				logger.info("Project Acceptance Criteria for {} is complete. Promotion is recommended.", commitInformation.getSourceBranchPath());
 				return ResponseEntity.status(HttpStatus.OK).build();
 			} else {
-				logger.info("Project Acceptance Criteria for {} is incomplete. Promotion is not recommended.", commitInformation.getPath());
+				logger.info("Project Acceptance Criteria for {} is incomplete. Promotion is not recommended.", commitInformation.getSourceBranchPath());
 				return ResponseEntity.status(HttpStatus.CONFLICT).build();
 			}
 		}

--- a/src/test/java/org/snomed/aag/data/validators/CommitInformationValidatorTest.java
+++ b/src/test/java/org/snomed/aag/data/validators/CommitInformationValidatorTest.java
@@ -5,6 +5,7 @@ import org.snomed.aag.data.pojo.CommitInformation;
 
 import java.util.Collections;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class CommitInformationValidatorTest {
@@ -32,12 +33,24 @@ class CommitInformationValidatorTest {
 	}
 
 	@Test
-	void validate_ShouldThrowException_WhenGivenNoPath() {
+	void validate_ShouldThrowException_WhenGivenNoSourceBranchPath() {
 		// given
 		CommitInformation commitInformation = new CommitInformation(null, CommitInformation.CommitType.PROMOTION, 10L, Collections.emptyMap());
 
 		// then
 		assertThrows(IllegalArgumentException.class, () -> {
+			// when
+			target.validate(commitInformation);
+		});
+	}
+
+	@Test
+	void validate_ShouldNotThrowException_WhenGivenNoTargetBranchPath() {
+		// given
+		CommitInformation commitInformation = new CommitInformation("source", null, CommitInformation.CommitType.PROMOTION, 10L, Collections.emptyMap());
+
+		// then
+		assertDoesNotThrow(() -> {
 			// when
 			target.validate(commitInformation);
 		});

--- a/src/test/java/org/snomed/aag/rest/ServiceIntegrationControllerTest.java
+++ b/src/test/java/org/snomed/aag/rest/ServiceIntegrationControllerTest.java
@@ -73,7 +73,7 @@ class ServiceIntegrationControllerTest extends AbstractTest {
 
 		// then
 		assertResponseStatus(resultActions, 400);
-		assertResponseBody(resultActions, buildErrorResponse(HttpStatus.BAD_REQUEST, "No path specified."));
+		assertResponseBody(resultActions, buildErrorResponse(HttpStatus.BAD_REQUEST, "No sourceBranchPath specified."));
 	}
 
 	@Test


### PR DESCRIPTION
FRI-54 is concerned with either allowing or disallowing a project promotion depending on whether the appropriate criteria have been completed. The previous PR related to FRI-54 submitted was not fully tested and had a slight oversight. 

Currently, when Snowstorm is promoting, the _target_ branch will be sent to AAG for criteria verification rather than the _source_ branch.