### PR TITLE
FRI-54 Return 204 if no PAC

### DIFF
--- a/src/main/java/org/snomed/aag/data/domain/ProjectAcceptanceCriteria.java
+++ b/src/main/java/org/snomed/aag/data/domain/ProjectAcceptanceCriteria.java
@@ -157,24 +157,6 @@ public class ProjectAcceptanceCriteria {
 		return projectAcceptanceCriteria;
 	}
 
-	public boolean hasCriteria() {
-		if (this.selectedProjectCriteriaIds == null && this.selectedTaskCriteriaIds == null) {
-			return false;
-		}
-
-		boolean projectCriteria = false;
-		if (this.selectedProjectCriteriaIds != null) {
-			projectCriteria = this.selectedProjectCriteriaIds.isEmpty();
-		}
-
-		boolean taskCriteria = false;
-		if (this.selectedTaskCriteriaIds != null) {
-			taskCriteria = this.selectedTaskCriteriaIds.isEmpty();
-		}
-
-		return !projectCriteria || !taskCriteria;
-	}
-
 	@Override
 	public String toString() {
 		return "ProjectAcceptanceCriteria{" +

--- a/src/test/java/org/snomed/aag/rest/ServiceIntegrationControllerTest.java
+++ b/src/test/java/org/snomed/aag/rest/ServiceIntegrationControllerTest.java
@@ -127,29 +127,8 @@ class ServiceIntegrationControllerTest extends AbstractTest {
 				);
 
 		// then
-		assertResponseStatus(resultActions, 404);
-		assertResponseBody(resultActions, buildErrorResponse(404, "No Project Acceptance Criteria found for branch."));
-	}
-
-	@Test
-	void receiveCommitInformation_ShouldReturnExpectedResponse_WhenPACHasNoCriteriaItems() throws Exception {
-		// given
-		String requestUrl = receiveCommitInformation();
-		String branchPath = "MAIN/projectA/taskB";
-		CommitInformation commitInformation = new CommitInformation(branchPath, CommitInformation.CommitType.PROMOTION, 1L, Collections.emptyMap());
-
-		givenProjectAcceptanceCriteriaExists(branchPath, 1);
-
-		// when
-		ResultActions resultActions = mockMvc
-				.perform(post(requestUrl)
-						.contentType(MediaType.APPLICATION_JSON)
-						.content(asJson(commitInformation))
-				);
-
-		// then
-		assertResponseStatus(resultActions, 409);
-		assertResponseBody(resultActions, buildErrorResponse(HttpStatus.CONFLICT.value(), "Project Acceptance Criteria has no Criteria Items."));
+		assertResponseStatus(resultActions, 204);
+		assertResponseBody(resultActions, String.format("No Project Acceptance Criteria found for branch %s. Returning " + HttpStatus.NO_CONTENT + ".", branchPath));
 	}
 
 	@Test


### PR DESCRIPTION
FRI-54 is concerned with blocking promotions for a given branch if the the PAC has not been completed. 

The bulk of the logic has been written, however, whilst testing FRI-54, it was suggested the service does not block promotion if no PAC has been configured for a given branch. 