### PR TITLE
FRI-127

### DIFF
--- a/src/main/java/org/snomed/aag/data/Constants.java
+++ b/src/main/java/org/snomed/aag/data/Constants.java
@@ -11,4 +11,10 @@ public class Constants {
 	 * Key in Branch metadata storing collection of author flags.
 	 */
 	public static final String AUTHOR_FLAG = "authorFlags";
+
+
+	/**
+	 * Key in Branch metadata storing whether Branch received content via a batch process.
+	 */
+	public static final String AUTHOR_FLAG_BATCH_CHANGE = "batch-change";
 }

--- a/src/main/java/org/snomed/aag/data/domain/ProjectAcceptanceCriteria.java
+++ b/src/main/java/org/snomed/aag/data/domain/ProjectAcceptanceCriteria.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.snomed.aag.rest.util.PathUtil;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.Transient;
 import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Field;
 import org.springframework.data.elasticsearch.annotations.FieldType;
@@ -34,6 +35,9 @@ public class ProjectAcceptanceCriteria {
 
 	@Field(type = FieldType.Keyword)
 	private Set<String> selectedTaskCriteriaIds;
+
+	@Transient
+	private boolean batch;
 
 	public ProjectAcceptanceCriteria() {
 	}
@@ -169,6 +173,15 @@ public class ProjectAcceptanceCriteria {
 		projectAcceptanceCriteria.setSelectedTaskCriteriaIds(this.selectedTaskCriteriaIds);
 
 		return projectAcceptanceCriteria;
+	}
+
+	@JsonIgnore
+	public boolean isBatch() {
+		return batch;
+	}
+
+	public void setBatch(boolean batch) {
+		this.batch = batch;
 	}
 
 	@Override


### PR DESCRIPTION
FRI-127 is concerned with returning certain criteria from authoring-acceptance-gateway whenever a snowstorm branch is flagged as having had content added via a batch process.

The authoring-acceptance-gateway will inspect the metadata associated with a branch and manipulate the criteria returned if the branch has the appropriate flag. 

[Snowstorm](https://github.com/IHTSDO/snowstorm/pull/328)

[Reporting Engine](https://github.com/IHTSDO/reporting-engine/pull/6)

[Authoring Acceptance Gateway](https://github.com/IHTSDO/authoring-acceptance-gateway/pull/18)